### PR TITLE
Support for pygments and dev branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ Apart from the theme and config file, other flags can be provided as a single st
 
 If you already have hugo installed in your container, this step will use the installed version. To override this behaviour, set `force_install` to `true`.
 
+## dev_flags, prod_branches and dev_branches (optional)
+
+These 3 optional parameters allow you to use different build flags for production and development branches. This setting will **override** the `config`, `flags` and `theme` parameters in builds on your development branches.
+
+### How does it work?
+
+First, set `dev_flags` to the flags you would like to use for your development branches. Your production branches will still use `config`, `flags` and `theme`.
+
+Next, set **either** `prod_branches` or `dev_branches`.
+
+`prod_branches` should contain a space delimited list of branches that you would like to mark as *production* branches.
+
+`dev_branches` should contain a space delimited list of branches that you would like to mark as *development* branches.
+
+E.g. with [git flow](http://nvie.com/posts/a-successful-git-branching-model/):
+
+```yml
+box: debian
+build:
+  steps:
+    - arjen/hugo-build:
+        version: "0.14"
+        theme: redlounge
+        config: my-production-config.toml
+        dev_flags: -D -F
+        prod_branches: master
+```
+
 # Example wercker.yml (Docker)
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Apart from the theme and config file, other flags can be provided as a single st
 
 If you already have hugo installed in your container, this step will use the installed version. To override this behaviour, set `force_install` to `true`.
 
+## disable_pygments (optional)
+
+If you don't need [support for pygments](http://gohugo.io/extras/highlighting/), you can speed up the build process by not installing it. Set `disable_pygments` to `true` to disable support for pygments.
+
 # Example wercker.yml (Docker)
 
 ```yml

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,14 @@ command_exists()
     hash "$1" 2>/dev/null
 }
 
+# http://stackoverflow.com/a/8574392/1592358
+contains_element ()
+{
+  local e
+  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
+  return 1
+}
+
 install_hugo()
 {
     # check if curl is installed
@@ -24,6 +32,24 @@ install_hugo()
     curl -sL https://github.com/spf13/hugo/releases/download/v${WERCKER_HUGO_BUILD_VERSION}/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64.tar.gz -o ${WERCKER_STEP_ROOT}/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64.tar.gz
     tar xzf hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64.tar.gz
     HUGO_COMMAND=${WERCKER_STEP_ROOT}/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64
+}
+
+# returns true (0) if we're on a development branch
+check_branches ()
+{
+    if [ -n "$WERCKER_HUGO_BUILD_PROD_BRANCHES" ]; then
+        arr=($WERCKER_HUGO_BUILD_PROD_BRANCHES)
+        if contains_element "$WERCKER_GIT_BRANCH" "${arr[@]}"; then
+            return 1
+        fi
+    elif [ -n "$WERCKER_HUGO_BUILD_DEV_BRANCHES" ]; then
+        arr=($WERCKER_HUGO_BUILD_DEV_BRANCHES)
+        if ! contains_element "$WERCKER_GIT_BRANCH" "${arr[@]}"; then
+            return 1
+        fi
+    else
+        return 0
+    fi
 }
 
 if [ "$WERCKER_HUGO_BUILD_VERSION" == "false" ]; then
@@ -45,6 +71,10 @@ fi
 
 if [ -n "$WERCKER_HUGO_BUILD_CONFIG" ]; then
     WERCKER_HUGO_BUILD_FLAGS=$WERCKER_HUGO_BUILD_FLAGS" --config="${WERCKER_SOURCE_DIR}/${WERCKER_HUGO_BUILD_CONFIG}
+fi
+
+if [ -z "$WERCKER_HUGO_BUILD_DEV_FLAGS" ] && check_branches; then
+    WERCKER_HUGO_BUILD_FLAGS=${WERCKER_HUGO_BUILD_DEV_FLAGS}
 fi
 
 if [ ! -n "$WERCKER_HUGO_BUILD_FORCE_INSTALL" ]; then

--- a/run.sh
+++ b/run.sh
@@ -7,14 +7,30 @@ command_exists()
     hash "$1" 2>/dev/null
 }
 
+SOURCES_UPDATED=false
+update_sources()
+{
+    if [ "$SOURCES_UPDATED" = false ] ; then
+        if command_exists apt-get; then
+            apt-get update
+        fi
+        if command_exists pacman; then
+            pacman -Syu
+        fi
+        SOURCES_UPDATED=true
+    fi 
+}
+
 install_hugo()
 {
     # check if curl is installed
     # install otherwise
     if ! command_exists curl; then
+        update_sources
         if command_exists apt-get; then
-            apt-get update
             apt-get install -y curl
+        elif command_exists pacman; then
+            pacman -S --noconfirm curl
         else
             yum install -y curl
         fi
@@ -26,16 +42,32 @@ install_hugo()
     HUGO_COMMAND=${WERCKER_STEP_ROOT}/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64
 }
 
+install_pygments()
+{
+    # check if pygments is installed
+    # install otherwise
+    if ! command_exists pygmentize; then
+        update_sources
+        if command_exists apt-get; then
+            apt-get install -y python3-pygments
+        elif command_exists pacman; then
+            pacman -S --noconfirm python-pygments
+        else
+            yum install -y python-pygments
+        fi
+    fi
+}
+
 if [ "$WERCKER_HUGO_BUILD_VERSION" == "false" ]; then
     echo "The Hugo version in your wercker.yml isn't set correctly. Please put quotes around it. We will continue using the latest version ($LATEST_HUGO_VERSION)."
     WERCKER_HUGO_BUILD_VERSION=""
 fi
 
-if [ ! -n "$WERCKER_HUGO_BUILD_VERSION" ]; then
+if [ -z "$WERCKER_HUGO_BUILD_VERSION" ]; then
     WERCKER_HUGO_BUILD_VERSION=$LATEST_HUGO_VERSION
 fi
 
-if [ ! -n "$WERCKER_HUGO_BUILD_FLAGS" ]; then
+if [ -z "$WERCKER_HUGO_BUILD_FLAGS" ]; then
     WERCKER_HUGO_BUILD_FLAGS=""
 fi
 
@@ -47,8 +79,17 @@ if [ -n "$WERCKER_HUGO_BUILD_CONFIG" ]; then
     WERCKER_HUGO_BUILD_FLAGS=$WERCKER_HUGO_BUILD_FLAGS" --config="${WERCKER_SOURCE_DIR}/${WERCKER_HUGO_BUILD_CONFIG}
 fi
 
-if [ ! -n "$WERCKER_HUGO_BUILD_FORCE_INSTALL" ]; then
+if [ -z "$WERCKER_HUGO_BUILD_FORCE_INSTALL" ]; then
     WERCKER_HUGO_BUILD_FORCE_INSTALL=false
+fi
+
+if [ -z "$WERCKER_HUGO_DISABLE_PYGMENTS" ]; then
+    WERCKER_HUGO_DISABLE_PYGMENTS=false
+fi
+
+# install pygments if it's not disabled
+if $WERCKER_HUGO_DISABLE_PYGMENTS != false; then
+    install_pygments
 fi
 
 #check if hugo is already installed in the container

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -24,3 +24,7 @@ properties:
         type: string
         default: false
         required: false
+    disable_pygments:
+        type: string
+        default: false
+        required: false

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -20,6 +20,18 @@ properties:
         type: string
         default: ""
         required: false
+    dev_flags:
+        type: string
+        default: ""
+        required: false
+    dev_branches:
+        type: string
+        default: ""
+        required: false
+    prod_branches:
+        type: string
+        default: ""
+        required: false
     force_install:
         type: string
         default: false


### PR DESCRIPTION
- support for pygments is added with parameter disable_python (so it is enabled by default)
- the install commands now also work on systems using the pacman package manager
- add support for different flags on different branches
