### PR TITLE
Update README to use more recent versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This step does not require any specific Wercker box or container, and should wor
 
 ## version (optional/recommended)
 
-Specifies the version of Hugo to be used, by default this is `"0.15"`. It is recommended to set this, so you don't accidentally build you site with a version it isn't ready for. Due to Wercker not being able to properly handle `0.x` version numbers, you will need to put quotes around the version number.
+Specifies the version of Hugo to be used, by default this is `"0.17"`. It is recommended to set this, so you don't accidentally build you site with a version it isn't ready for. Due to Wercker not being able to properly handle `0.x` version numbers, you will need to put quotes around the version number.
 
 Note that you don't have to provide a version if you already have Hugo installed. If you wish to install a specific version regardless of what is running on your container, you can override this using the `force_install` parameter.
 
@@ -27,7 +27,7 @@ Note that you don't have to provide a version if you already have Hugo installed
 New in version 1.8 is support for the `HEAD` version. This will pull in the latest version from GitHub and compile it. This requires you to provide the version as below. Take note that this means using a version of Hugo that is not released and might be unstable, so use this at your own risk.
 
 ```yml
-box: debian
+box: golang:latest
 build:
   steps:
     - arjen/hugo-build:
@@ -80,7 +80,7 @@ box: debian
 build:
   steps:
     - arjen/hugo-build:
-        version: "0.15"
+        version: "0.17"
         theme: redlounge
         config: my-production-config.toml
         dev_flags: -D -F
@@ -94,7 +94,7 @@ box: debian
 build:
   steps:
     - arjen/hugo-build:
-        version: "0.15"
+        version: "0.17"
         theme: redlounge
         config: second-config.toml
         flags: --disableSitemap=true
@@ -107,7 +107,7 @@ box: wercker/default
 build:
   steps:
     - arjen/hugo-build:
-        version: "0.15"
+        version: "0.17"
         theme: redlounge
         config: second-config.toml
         flags: --disableSitemap=true


### PR DESCRIPTION
The default version is now `0.17` instead of `0.15`.

The `debian` box installs golang 1.3 via `apt_get`, which fails to install the lib crypto (`../gopath/src/golang.org/x/crypto/ed25519/ed25519.go:54: undefined: crypto.SignerOpts` - this was added on golang 1.4). Using the latest version of golang is probably a better example to use with `HEAD` version.
