### PR TITLE
update to hugo 0.20.6

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -111,14 +111,18 @@ install_hugo()
         if [ "$WERCKER_HUGO_BUILD_VERSION" == "0.16" ]; then
           curl -sL https://github.com/spf13/hugo/releases/download/v0.16/hugo_0.16_linux-64bit.tgz -o hugo_0.16_linux-64bit.tgz
           tar xzf hugo_0.16_linux-64bit.tgz
-          HUGO_COMMAND=${WERCKER_STEP_ROOT}/hugo
         elif [ "$WERCKER_HUGO_BUILD_VERSION" == "0.15" ] || [ "$WERCKER_HUGO_BUILD_VERSION" == "0.14" ] || [ "$WERCKER_HUGO_BUILD_VERSION" == "0.13" ]; then
           curl -sL https://github.com/spf13/hugo/releases/download/v${WERCKER_HUGO_BUILD_VERSION}/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64.tar.gz -o ${WERCKER_STEP_ROOT}/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64.tar.gz
           tar xzf hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64.tar.gz
-          HUGO_COMMAND=${WERCKER_STEP_ROOT}/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64
         else
           curl -sL https://github.com/spf13/hugo/releases/download/v${WERCKER_HUGO_BUILD_VERSION}/hugo_${WERCKER_HUGO_BUILD_VERSION}_Linux-64bit.tar.gz -o hugo_${WERCKER_HUGO_BUILD_VERSION}_Linux-64bit.tar.gz
           tar xzf hugo_${WERCKER_HUGO_BUILD_VERSION}_Linux-64bit.tar.gz
+        fi
+
+        # this was the location in 0.16, and again after 0.20.4
+        if [ -x "${WERCKER_STEP_ROOT}/hugo" ]; then
+          HUGO_COMMAND=${WERCKER_STEP_ROOT}/hugo
+        else
           HUGO_COMMAND=${WERCKER_STEP_ROOT}/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64/hugo_${WERCKER_HUGO_BUILD_VERSION}_linux_amd64
         fi
     fi

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LATEST_HUGO_VERSION=0.20.2
+LATEST_HUGO_VERSION=0.20.6
 
 command_exists()
 {

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,12 +1,12 @@
 name: hugo-build
-version: 1.16.2
+version: 1.16.3
 description: |
     Downloads Hugo (http://gohugo.io) and runs it on the source code in order to generate the static site.
 type: build
 properties:
     version:
         type: string
-        default: "0.20.2"
+        default: "0.20.6"
         required: false
     theme:
         type: string

--- a/wercker.yml
+++ b/wercker.yml
@@ -8,14 +8,14 @@ build:
         name: Install latest 2 versions of Hugo
         code: |
           mkdir bin
+          curl -sL https://github.com/spf13/hugo/releases/download/v0.20.6/hugo_0.20.6_Linux-64bit.tar.gz -o hugo_0.20.6_Linux-64bit.tar.gz
+          mkdir 0.20.6
+          tar xzf hugo_0.20.6_Linux-64bit.tar.gz --directory 0.20.6
+          mv 0.20.6/hugo bin/hugo_0.20.6
           curl -sL https://github.com/spf13/hugo/releases/download/v0.20.2/hugo_0.20.2_Linux-64bit.tar.gz -o hugo_0.20.2_Linux-64bit.tar.gz
           mkdir 0.20.2
           tar xzf hugo_0.20.2_Linux-64bit.tar.gz --directory 0.20.2
           mv 0.20.2/hugo_0.20.2_linux_amd64/hugo_0.20.2_linux_amd64 bin/hugo_0.20.2
-          curl -sL https://github.com/spf13/hugo/releases/download/v0.20/hugo_0.20_Linux-64bit.tar.gz -o hugo_0.20_Linux-64bit.tar.gz
-          mkdir 0.20
-          tar xzf hugo_0.20_Linux-64bit.tar.gz --directory 0.20
-          mv 0.20/hugo_0.20_linux_amd64/hugo_0.20_linux_amd64 bin/hugo_0.20
 
     - script:
         name: Move the important stuff to output


### PR DESCRIPTION
Since the binary deliverables changed in 0.20.4, adjust code to detect the old and new schemes.

This step was tested with 0.20, 0.20.2, 0.20.4 and 0.20.6